### PR TITLE
fix: remove version re-declaration of managed deps

### DIFF
--- a/connectivity/connectivity-demos-test/pom.xml
+++ b/connectivity/connectivity-demos-test/pom.xml
@@ -14,7 +14,6 @@
   <packaging>iar-integration-test</packaging>
   <properties>
     <web.tester.version>13.1.0</web.tester.version>
-    <jersey.version>2.46</jersey.version>
     <wss4j.version>2.4.3</wss4j.version>
     <project-build-plugin>13.1.1-SNAPSHOT</project-build-plugin>
   </properties>
@@ -28,7 +27,6 @@
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>${jersey.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -40,7 +38,6 @@
     <dependency>
       <groupId>org.glassfish.jersey.connectors</groupId>
       <artifactId>jersey-apache-connector</artifactId>
-      <version>${jersey.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -91,7 +88,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.17.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/workflow/workflow-demos-test/pom.xml
+++ b/workflow/workflow-demos-test/pom.xml
@@ -31,7 +31,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.17.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
first fruits of the parent-pom introduction :clap: 

... fixes warnings :warning: ... due to otherwise re-declared managed versions

![manager-warnings](https://github.com/user-attachments/assets/0b863b62-7245-46e8-98b0-b5878b2eece9)

