### PR TITLE
Retry open firefox after closing webdriver

### DIFF
--- a/html-dialog/html-dialog-demos-test/src_test/ch/ivyteam/htmldialog/demo/WebTestExcelExportIT.java
+++ b/html-dialog/html-dialog-demos-test/src_test/ch/ivyteam/htmldialog/demo/WebTestExcelExportIT.java
@@ -13,6 +13,7 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
@@ -22,6 +23,8 @@ import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.FileDownloadMode;
 import com.codeborne.selenide.Selenide;
 
+import ch.ivyteam.htmldialog.server.test.ProcessUtil;
+
 @IvyWebTest
 public class WebTestExcelExportIT {
 
@@ -30,7 +33,15 @@ public class WebTestExcelExportIT {
     Selenide.closeWebDriver();
     Configuration.proxyEnabled = true;
     Configuration.fileDownload = FileDownloadMode.PROXY;
-    Selenide.open();
+    ProcessUtil.open();
+  }
+
+  @AfterAll
+  static void cleanUp() {
+    Selenide.closeWebDriver();
+    Configuration.proxyEnabled = false;
+    Configuration.fileDownload = FileDownloadMode.HTTPGET;
+    ProcessUtil.open();
   }
 
   @Test

--- a/html-dialog/html-dialog-demos-test/src_test/ch/ivyteam/htmldialog/demo/WebTestInputDownloadIT.java
+++ b/html-dialog/html-dialog-demos-test/src_test/ch/ivyteam/htmldialog/demo/WebTestInputDownloadIT.java
@@ -15,6 +15,7 @@ import java.nio.charset.Charset;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
@@ -24,6 +25,8 @@ import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.FileDownloadMode;
 import com.codeborne.selenide.Selenide;
 
+import ch.ivyteam.htmldialog.server.test.ProcessUtil;
+
 @IvyWebTest
 public class WebTestInputDownloadIT {
 
@@ -32,7 +35,15 @@ public class WebTestInputDownloadIT {
     Selenide.closeWebDriver();
     Configuration.proxyEnabled = true;
     Configuration.fileDownload = FileDownloadMode.PROXY;
-    Selenide.open();
+    ProcessUtil.open();
+  }
+
+  @AfterAll
+  static void cleanUp() {
+    Selenide.closeWebDriver();
+    Configuration.proxyEnabled = false;
+    Configuration.fileDownload = FileDownloadMode.HTTPGET;
+    ProcessUtil.open();
   }
 
   @Test

--- a/html-dialog/html-dialog-demos-test/src_test/ch/ivyteam/htmldialog/demo/WebTestOutputIT.java
+++ b/html-dialog/html-dialog-demos-test/src_test/ch/ivyteam/htmldialog/demo/WebTestOutputIT.java
@@ -24,7 +24,8 @@ import com.axonivy.ivy.webtest.primeui.PrimeUi;
 import com.axonivy.ivy.webtest.primeui.widget.SelectManyCheckbox;
 import com.axonivy.ivy.webtest.primeui.widget.SelectOneMenu;
 import com.axonivy.ivy.webtest.primeui.widget.Table;
-import com.codeborne.selenide.Selenide;
+
+import ch.ivyteam.htmldialog.server.test.ProcessUtil;
 
 @IvyWebTest
 class WebTestOutputIT {
@@ -201,7 +202,7 @@ class WebTestOutputIT {
   void barcode() {
     startProcess("145D180807C60B4B/BarcodeDemo.ivp");
     var element = $(By.id("qr")).shouldBe(visible);
-    Selenide.open(element.getAttribute("src"));
+    ProcessUtil.open(element.getAttribute("src"));
     $(By.tagName("svg")).shouldBe(visible);
     $(By.tagName("path")).shouldBe(visible);
   }

--- a/html-dialog/html-dialog-demos-test/src_test/ch/ivyteam/htmldialog/server/test/ProcessUtil.java
+++ b/html-dialog/html-dialog-demos-test/src_test/ch/ivyteam/htmldialog/server/test/ProcessUtil.java
@@ -4,6 +4,7 @@ import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 
 import com.axonivy.ivy.webtest.engine.EngineUrl;
 import com.codeborne.selenide.Selenide;
@@ -11,12 +12,32 @@ import com.codeborne.selenide.Selenide;
 public class ProcessUtil {
 
   public static void startProcess(String pathToIvp) {
-    Selenide.open(EngineUrl.createProcessUrl("/html-dialog-demos/" + pathToIvp));
+    open(EngineUrl.createProcessUrl("/html-dialog-demos/" + pathToIvp));
     $(By.id("menuform")).shouldBe(visible);
   }
 
   public static void startOfflineProcess() {
-    Selenide.open(
-        EngineUrl.createProcessUrl("/html-dialog-demos/150425B095B4FB54/ClientSideValidationDemo.ivp"));
+    open(EngineUrl.createProcessUrl("/html-dialog-demos/150425B095B4FB54/ClientSideValidationDemo.ivp"));
+  }
+
+  public static void open() {
+    open(EngineUrl.base());
+  }
+
+  public static void open(String url) {
+    open(url, 1);
+  }
+
+  private static void open(String url, int retry) {
+    if (retry >= 3) {
+      throw new RuntimeException("Could not start browser instance.");
+    }
+    try {
+      Selenide.open(url);
+    } catch (TimeoutException ex) {
+      System.out.println("Browser didn't respond in time, retry: " + retry);
+      Selenide.closeWebDriver();
+      open(url, retry++);
+    }
   }
 }


### PR DESCRIPTION
Same approach is currently also used in the dev-wf-ui and the engine-cockpit.
It seems that when the selenium webdriver is closed sometimes it cannot open a new firefox instance. Maybe because the proxy is enabled or something like that, not sure. 
But now it it will be retried to open a new webdriver + the proxy is disabled after the tests which use it.

I will merge this also to 12 and 13.1