### PR TITLE
distinct src_generated dir

### DIFF
--- a/connectivity/connectivity-demos/.classpath
+++ b/connectivity/connectivity-demos/.classpath
@@ -15,7 +15,7 @@
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="target/classes" path="src_generated">
+	<classpathentry kind="src" output="target/classes" path="src_generatedClient">
 		<attributes>
 			<attribute name="ignore_optional_problems" value="true"/>
 			<attribute name="optional" value="true"/>

--- a/connectivity/connectivity-demos/.gitignore
+++ b/connectivity/connectivity-demos/.gitignore
@@ -1,0 +1,2 @@
+src_generatedClient/
+

--- a/connectivity/connectivity-demos/pom.xml
+++ b/connectivity/connectivity-demos/pom.xml
@@ -62,7 +62,7 @@
         <artifactId>project-build-plugin</artifactId>
         <configuration>
           <compilerOptions>
-            <compilerOption>-nowarn:[${project.basedir}/src_generated/io]</compilerOption>
+            <compilerOption>-nowarn:[${project.basedir}/src_generatedClient/]</compilerOption>
           </compilerOptions>
         </configuration>
       </plugin>
@@ -85,7 +85,7 @@
           </execution>
         </executions>
         <configuration>
-          <outputDirectory>${basedir}/src_generated</outputDirectory>
+          <outputDirectory>${basedir}/src_generatedClient</outputDirectory>
           <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
         </configuration>
       </plugin>


### PR DESCRIPTION
fix the build: src_generated is now automatically 'cleaned' on project-build-plugin:compile ... therefore we use another src_dir for restServiceClient codegen artifacts.