### PR TITLE
freeze project-build-plugin to 12.0.5 for LTS release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   build:
-    uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v5
+    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v5
     with:
       mvnArgs: -Dmaven.test.skip=true # We run the tests on our Jenkins CI

--- a/connectivity/connectivity-demos-test/pom.xml
+++ b/connectivity/connectivity-demos-test/pom.xml
@@ -9,7 +9,7 @@
   <properties>
     <wss4j.version>2.4.3</wss4j.version>
     <jersey.version>2.47</jersey.version>
-    <project-build-plugin>12.0.6-SNAPSHOT</project-build-plugin>
+    <project-build-plugin>12.0.5</project-build-plugin>
     <web.tester.version>12.0.1</web.tester.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/connectivity/connectivity-demos/pom.xml
+++ b/connectivity/connectivity-demos/pom.xml
@@ -10,7 +10,7 @@
   </organization>
 
   <properties>
-    <project-build-plugin>12.0.6-SNAPSHOT</project-build-plugin>
+    <project-build-plugin>12.0.5</project-build-plugin>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/error-handling/error-handling-demos/pom.xml
+++ b/error-handling/error-handling-demos/pom.xml
@@ -10,7 +10,7 @@
   </organization>
 
   <properties>
-    <project-build-plugin>12.0.6-SNAPSHOT</project-build-plugin>
+    <project-build-plugin>12.0.5</project-build-plugin>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/html-dialog/html-dialog-demos-test/pom.xml
+++ b/html-dialog/html-dialog-demos-test/pom.xml
@@ -7,7 +7,7 @@
   <packaging>iar-integration-test</packaging>
 
   <properties>
-    <project-build-plugin>12.0.6-SNAPSHOT</project-build-plugin>
+    <project-build-plugin>12.0.5</project-build-plugin>
     <web.tester.version>12.0.1</web.tester.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/html-dialog/html-dialog-demos/pom.xml
+++ b/html-dialog/html-dialog-demos/pom.xml
@@ -11,7 +11,7 @@
   </organization>
 
   <properties>
-    <project-build-plugin>12.0.6-SNAPSHOT</project-build-plugin>
+    <project-build-plugin>12.0.5</project-build-plugin>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/quick-start-tutorial/quick-start-tutorial/pom.xml
+++ b/quick-start-tutorial/quick-start-tutorial/pom.xml
@@ -10,7 +10,7 @@
   </organization>
 
   <properties>
-    <project-build-plugin>12.0.6-SNAPSHOT</project-build-plugin>
+    <project-build-plugin>12.0.5</project-build-plugin>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/rule-engine/rule-engine-demos-test/pom.xml
+++ b/rule-engine/rule-engine-demos-test/pom.xml
@@ -7,7 +7,7 @@
   <packaging>iar-integration-test</packaging>
 
   <properties>
-    <project-build-plugin>12.0.6-SNAPSHOT</project-build-plugin>
+    <project-build-plugin>12.0.5</project-build-plugin>
     <web.tester.version>12.0.1</web.tester.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/rule-engine/rule-engine-demos/pom.xml
+++ b/rule-engine/rule-engine-demos/pom.xml
@@ -13,7 +13,7 @@
   </organization>
 
   <properties>
-    <project-build-plugin>12.0.6-SNAPSHOT</project-build-plugin>
+    <project-build-plugin>12.0.5</project-build-plugin>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/workflow/workflow-demos-test/pom.xml
+++ b/workflow/workflow-demos-test/pom.xml
@@ -7,7 +7,7 @@
   <packaging>iar-integration-test</packaging>
 
   <properties>
-    <project-build-plugin>12.0.6-SNAPSHOT</project-build-plugin>
+    <project-build-plugin>12.0.5</project-build-plugin>
     <web.tester.version>12.0.1</web.tester.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/workflow/workflow-demos/pom.xml
+++ b/workflow/workflow-demos/pom.xml
@@ -10,7 +10,7 @@
   </organization>
 
   <properties>
-    <project-build-plugin>12.0.6-SNAPSHOT</project-build-plugin>
+    <project-build-plugin>12.0.5</project-build-plugin>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 


### PR DESCRIPTION
use a released version, in order to bypass '-SNAPSHOT' restriction of maven-release-plugin.